### PR TITLE
Don't pass subnet id's to storage accounts :fire:

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -236,9 +236,6 @@
         "parameters": {
           "storageAccountName": {
             "value": "[variables('sharedARMStorageName')]"
-          },
-          "subnetResourceIdList": {
-            "value": "[reference('get-subnet-resourceid-list').outputs.subnetResourceIdList.value]"
           }
         }
       }


### PR DESCRIPTION
It would appear that "Allow Trusted Microsoft Services" for Storage firewalls does not yet support SQL.

https://docs.microsoft.com/en-us/azure/storage/common/storage-network-security#trusted-microsoft-services

This blocks the deployment from adding a firewall protected storage account to the sql server resource.

This PR removes firewall support for shared storage accounts.


