### PR TITLE
Added AKSEnterpriseApplicationObjectId for key vault access policies

### DIFF
--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -46,11 +46,18 @@
         "environmentVariable": "backupManagementServiceObjectId"
       }
     },
-    "diskEncryptionAppRegistrationObjectId": {
+    "diskEncryptionEnterpriseApplicationObjectId": {
       "type": "string",
       "metadata": {
-        "description": "Object Id for the disk Encryption App Registration",
-        "environmentVariable": "diskEncryptionAppRegistrationObjectId"
+        "description": "Object Id for the disk Encryption Enterprise Application",
+        "environmentVariable": "diskEncryptionEnterpriseApplicationObjectId"
+      }
+    },
+    "AKSEnterpriseApplicationObjectId": {
+      "type": "string",
+      "metadata": {
+        "description": "Object Id for the AKS Enterprise Application",
+        "environmentVariable": "AKSEnterpriseApplicationObjectId"
       }
     },
     "environments": {
@@ -199,7 +206,7 @@
         }
       },
       {
-        "objectId": "[parameters('diskEncryptionAppRegistrationObjectId')]",
+        "objectId": "[parameters('diskEncryptionEnterpriseApplicationObjectId')]",
         "tenantId": "[subscription().tenantId]",
         "permissions": {
           "keys": [
@@ -207,6 +214,19 @@
           ],
           "secrets": [
             "Set"
+          ]
+        }
+      },
+      {
+        "condition": "[greater(length(parameters('AKSEnterpriseApplicationObjectId')), 0)]",
+        "objectId": "[parameters('AKSEnterpriseApplicationObjectId')]",
+        "tenantId": "[subscription().tenantId]",
+        "permissions": {
+          "secrets": [
+            "Get"
+          ],
+          "certificates": [
+            "Get"
           ]
         }
       },

--- a/tests/modules/UnitTest.Helpers.psm1
+++ b/tests/modules/UnitTest.Helpers.psm1
@@ -9,7 +9,7 @@ function Set-MockEnvironment {
     $ENV:keyVaultSecretAccessObjectIds = "['fb0eac10-bda1-4410-9f8f-f4d381268d13']"
     $ENV:sqlServerActiveDirectoryAdminObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:diskEncryptionEnterpriseApplicationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
-    $ENV:AKSEnterpriseApplicationObjectId = ""
+    $ENV:AKSEnterpriseApplicationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:backupManagementServiceObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:gatewaySubnetCount = 1
     $ENV:internalAppSubnetCount = 1

--- a/tests/modules/UnitTest.Helpers.psm1
+++ b/tests/modules/UnitTest.Helpers.psm1
@@ -8,7 +8,8 @@ function Set-MockEnvironment {
     $ENV:keyVaultSecretCertificateAccessObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:keyVaultSecretAccessObjectIds = "['fb0eac10-bda1-4410-9f8f-f4d381268d13']"
     $ENV:sqlServerActiveDirectoryAdminObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
-    $ENV:diskEncryptionAppRegistrationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
+    $ENV:diskEncryptionEnterpriseApplicationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
+    $ENV:AKSEnterpriseApplicationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:backupManagementServiceObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:gatewaySubnetCount = 1
     $ENV:internalAppSubnetCount = 1
@@ -30,7 +31,8 @@ function Clear-MockEnvironment {
         "ENV:keyVaultSecretCertificateAccessObjectId",
         "ENV:keyVaultSecretAccessObjectIds",
         "ENV:sqlServerActiveDirectoryAdminObjectId",
-        "ENV:diskEncryptionAppRegistrationObjectId",
+        "ENV:diskEncryptionEnterpriseApplicationObjectId",
+        "ENV:AKSEnterpriseApplicationObjectId",
         "ENV:backupManagementServiceObjectId",
         "ENV:gatewaySubnetCount",
         "ENV:internalAppSubnetCount",

--- a/tests/modules/UnitTest.Helpers.psm1
+++ b/tests/modules/UnitTest.Helpers.psm1
@@ -9,7 +9,7 @@ function Set-MockEnvironment {
     $ENV:keyVaultSecretAccessObjectIds = "['fb0eac10-bda1-4410-9f8f-f4d381268d13']"
     $ENV:sqlServerActiveDirectoryAdminObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:diskEncryptionEnterpriseApplicationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
-    $ENV:AKSEnterpriseApplicationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
+    $ENV:AKSEnterpriseApplicationObjectId = ""
     $ENV:backupManagementServiceObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:gatewaySubnetCount = 1
     $ENV:internalAppSubnetCount = 1

--- a/tests/resources/mock.template.json
+++ b/tests/resources/mock.template.json
@@ -46,11 +46,18 @@
         "environmentVariable": "backupManagementServiceObjectId"
       }
     },
-    "diskEncryptionAppRegistrationObjectId": {
+    "diskEncryptionEnterpriseApplicationObjectId": {
       "type": "string",
       "metadata": {
-        "description": "Object Id for the disk Encryption App Registration",
-        "environmentVariable": "diskEncryptionAppRegistrationObjectId"
+        "description": "Object Id for the disk Encryption Enterprise Application",
+        "environmentVariable": "diskEncryptionEnterpriseApplicationObjectId"
+      }
+    },
+    "AKSEnterpriseApplicationObjectId": {
+      "type": "string",
+      "metadata": {
+        "description": "Object Id for the AKS Enterprise Application",
+        "environmentVariable": "AKSEnterpriseApplicationObjectId"
       }
     },
     "environments": {


### PR DESCRIPTION
Added AKSEnterpriseApplicationObjectId for key vault access policies
-New access policy created if AKSEnterpriseApplicationObjectId has a non-empty value

Renamed diskEncryptionAppRegistrationObjectId to diskEncryptionEnterpriseApplicationObjectId