### PR TITLE
Added support to ensure dev AKS cluster route table is not removed during deployment

### DIFF
--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -95,10 +95,27 @@
       "metadata": {
         "description": "A list of service endpoints to configure on the subnets provisioned in the vnet."
       }
+    },
+    "AKSRouteTableName": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Name of the AKS Route Table to be included in the DEV management subnet mgmt-sn-0"
+      }
+    },
+    "AKSRouteTableResourceGroupName": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Name of the DEV Resource Group where the AKS Route Table resides, used for the resourceId function to get the AKS Route Table resource"
+      }
     }
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
+    "aksRouteTableId": {
+      "id": "[if(not(bool(equals(parameters('AKSRouteTableName'),'Disabled'))), resourceId(parameters('AKSRouteTableResourceGroupName'), 'Microsoft.Network/routeTables', parameters('AKSRouteTableName')),'')]"
+    },
     "subnetDelegations": [
       {
         "name": "webapp",
@@ -135,7 +152,8 @@
         "input": {
           "name": "[concat(parameters('managementSubnetNamePrefix'), '-', copyIndex('managementSubnetCopy'))]",
           "properties": {
-            "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 5, copyIndex('managementSubnetCopy'), parameters('subnetAddressSpaceCIDR'))]"
+            "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 5, copyIndex('managementSubnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
+            "routeTable": "[if(and(not(bool(equals(parameters('AKSRouteTableName'),'Disabled'))), bool(equals(copyIndex('managementSubnetCopy'), 0))), variables('aksRouteTableId'), json('null'))]"
           }
         }
       },

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -61,6 +61,22 @@
         "environmentVariable": "AKSEnterpriseApplicationObjectId"
       }
     },
+    "AKSRouteTableName": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Name of the AKS Route Table to be included in the DEV management subnet mgmt-sn-0",
+        "environmentVariable": "AKSRouteTableName"
+      }
+    },
+    "AKSRouteTableResourceGroupName": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Name of the DEV Resource Group where the AKS Route Table resides, used for the resourceId function to get the AKS Route Table resource",
+        "environmentVariable": "AKSRouteTableResourceGroupName"
+      }
+    },
     "environments": {
       "type": "array",
       "defaultValue": [],
@@ -316,6 +332,12 @@
           },
           "virtualNetworkAddressSpacePrefix": {
             "value": "10.0"
+          },
+          "AKSRouteTableName": {
+            "value": "[parameters('AKSRouteTableName')]"
+          },
+          "AKSRouteTableResourceGroupName": {
+            "value": "[parameters('AKSRouteTableResourceGroupName')]"
           }
         }
       }

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -190,7 +190,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/DASD-6571_Add_AKS_Route_Table_Fix/",
+    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/master/",
     "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
     "keyVaultName": "[concat(variables('resourceNamePrefix'),'-kv')]",
     "automationAccountName": "[concat(variables('resourceNamePrefix'),'-aa')]",

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -190,7 +190,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/master/",
+    "sharedDeploymentUrlBase": "https://github.com/SkillsFundingAgency/das-shared-infrastructure/tree/DASD-6571_Add_AKS_Route_Table_Fix/",
     "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
     "keyVaultName": "[concat(variables('resourceNamePrefix'),'-kv')]",
     "automationAccountName": "[concat(variables('resourceNamePrefix'),'-aa')]",

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -190,7 +190,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-    "sharedDeploymentUrlBase": "https://github.com/SkillsFundingAgency/das-shared-infrastructure/tree/DASD-6571_Add_AKS_Route_Table_Fix/",
+    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/DASD-6571_Add_AKS_Route_Table_Fix/",
     "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
     "keyVaultName": "[concat(variables('resourceNamePrefix'),'-kv')]",
     "automationAccountName": "[concat(variables('resourceNamePrefix'),'-aa')]",

--- a/tests/modules/UnitTest.Helpers.psm1
+++ b/tests/modules/UnitTest.Helpers.psm1
@@ -10,6 +10,8 @@ function Set-MockEnvironment {
     $ENV:sqlServerActiveDirectoryAdminObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:diskEncryptionEnterpriseApplicationObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:AKSEnterpriseApplicationObjectId = "Disabled"
+    $ENV:AKSRouteTableName = "Disabled"
+    $ENV:AKSRouteTableResourceGroupName = "Disabled"
     $ENV:backupManagementServiceObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
     $ENV:gatewaySubnetCount = 1
     $ENV:internalAppSubnetCount = 1
@@ -33,6 +35,8 @@ function Clear-MockEnvironment {
         "ENV:sqlServerActiveDirectoryAdminObjectId",
         "ENV:diskEncryptionEnterpriseApplicationObjectId",
         "ENV:AKSEnterpriseApplicationObjectId",
+        "ENV:AKSRouteTableName",
+        "ENV:AKSRouteTableResourceGroupName",
         "ENV:backupManagementServiceObjectId",
         "ENV:gatewaySubnetCount",
         "ENV:internalAppSubnetCount",

--- a/tests/resources/mock.template.json
+++ b/tests/resources/mock.template.json
@@ -60,6 +60,22 @@
         "environmentVariable": "AKSEnterpriseApplicationObjectId"
       }
     },
+    "AKSRouteTableName": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Name of the AKS Route Table to be included in the DEV management subnet mgmt-sn-0",
+        "environmentVariable": "AKSRouteTableName"
+      }
+    },
+    "AKSRouteTableResourceGroupName": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Name of the DEV Resource Group where the AKS Route Table resides, used for the resourceId function to get the AKS Route Table resource",
+        "environmentVariable": "AKSRouteTableResourceGroupName"
+      }
+    },
     "environments": {
       "type": "array",
       "defaultValue": [],


### PR DESCRIPTION
**templates/network.template.json**
- Added two new parameters `AKSRouteTableName` and `AKSRouteTableResourceGroupName`. Both with default values of `Disabled`
- Added a variable `aksRouteTableId`. This variable uses multiple ARM template functions to only get the ResourceId of the dev AKS route table if the value of the `AKSRouteTableName` parameter is not `Disabled`. 
- The `managementSubnetCopy` subnet will include the `routeTable` object if the parameter `AKSRouteTableName` is not equal to `Disabled` and the current copy index for `managementSubnetCopy` is `0`. The variable `aksRouteTableId` will be used, otherwise null will be used.

**templates/subscription.template.json**
- Added two new parameters `AKSRouteTableName` and `AKSRouteTableResourceGroupName`. Both with default values of `Disabled`
- Passing the two new parameters to the deployment resource:
` "name": "[concat('virtual-network-west-europe-', variables('resourceNamePrefix'))]"`

**tests/modules/UnitTest.Helpers.psm1**
- Added AKSRouteTableName environment variable with a value of Disabled.
- Added ASKRouteTableResourceGroupName environment variable with a value of Disabled.

**tests/resources/mock.template.json**
- Added two new parameters `AKSRouteTableName` and `AKSRouteTableResourceGroupName`. Both with default values of `Disabled`