### PR TITLE
Deployed shared subnets separately from virtual networks

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -349,7 +349,7 @@
             "value": "[variables('virtualNetworkName')]"
           },
           "subnetConfiguration": {
-            "value": "[reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.subnetConfiguration.value]"
+            "value": "[reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.backendSubnetConfiguration.value]"
           }
         }
       }

--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -62,6 +62,12 @@
         "description": "Virtual network address prefix for the environment vnet"
       }
     },
+    "virtualNetworkDeploy": {
+      "type": "string",
+      "metadata": {
+        "description": "Deploys the Virtual Network and deletes all subnets if Enabled https://github.com/Azure/azure-quickstart-templates/issues/2786"
+      }
+    },
     "gatewaySubnetCount": {
       "type": "int",
       "defaultValue": 1,
@@ -215,12 +221,11 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/master/",
+    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/separate-subnet-deployment/",
     "environmentName": "[toLower(parameters('environmentName'))]",
     "resourceNamePrefix": "[toLower(concat('das-', variables('environmentName'),'-shared'))]",
     "sharedFrontEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'fe-asp')]",
     "sharedBackEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'be-asp')]",
-    "apimEndpointAppServicePlanName": "[concat('das-', variables('environmentName'),'-apimendp-asp')]",
     "sharedFrontEndAppGatewayPublicIpName": "[concat(variables('resourceNamePrefix'),'fe-ag-pip')]",
     "firewallsResourceGroup": "[toLower(concat('das-', variables('environmentName'),'-firewall-rg'))]",
     "apimResourceGroup": "[toLower(concat('das-', variables('environmentName'),'-apim-rg'))]",
@@ -286,6 +291,9 @@
           },
           "virtualNetworkAddressSpacePrefix": {
             "value": "[parameters('virtualNetworkAddressSpacePrefix')]"
+          },
+          "virtualNetworkDeploy": {
+            "value": "[parameters('virtualNetworkDeploy')]"
           },
           "serviceEndpointList": {
             "value": "[variables('subnetServiceEndpointList')]"

--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -221,7 +221,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/separate-subnet-deployment/",
+    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/master/",
     "environmentName": "[toLower(parameters('environmentName'))]",
     "resourceNamePrefix": "[toLower(concat('das-', variables('environmentName'),'-shared'))]",
     "sharedFrontEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'fe-asp')]",

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -22,6 +22,17 @@
         "description": "The CIDR notation of the Vnet address space"
       }
     },
+    "virtualNetworkDeploy": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "allowedValues": [
+        "Disabled",
+        "Enabled"
+      ],
+      "metadata": {
+        "description": "Deploys the Virtual Network and deletes all subnets if Enabled https://github.com/Azure/azure-quickstart-templates/issues/2786"
+      }
+    },
     "subnetAddressSpaceCIDR": {
       "type": "string",
       "defaultValue": "/24",
@@ -121,8 +132,7 @@
     },
     "serviceEndpointList": {
       "type": "array",
-      "defaultValue": [
-      ],
+      "defaultValue": [],
       "metadata": {
         "description": "A list of service endpoints to configure on the subnets provisioned in the vnet."
       }
@@ -171,7 +181,7 @@
     }
   },
   "variables": {
-    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
+    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/separate-subnet-deployment/templates/",
     "aksRouteTableId": {
       "id": "[if(not(bool(equals(parameters('AKSRouteTableName'),'Disabled'))), resourceId(parameters('AKSRouteTableResourceGroupName'), 'Microsoft.Network/routeTables', parameters('AKSRouteTableName')),'')]"
     },
@@ -192,16 +202,7 @@
         }
       }
     ],
-    "serviceEndpointsEmpty": [
-    ],
     "copy": [
-      {
-        "name": "serviceEndpoints",
-        "count": "[if(greater(length(parameters('serviceEndpointList')), 0), length(parameters('serviceEndpointList')), 1)]",
-        "input": {
-          "service": "[if(greater(length(parameters('serviceEndpointList')), 0), parameters('serviceEndpointList')[copyIndex('serviceEndPoints')], json('null'))]"
-        }
-      },
       {
         "name": "gatewaySubnetCopy",
         "count": "[if(greater(parameters('gatewaySubnetCount'), 0), parameters('gatewaySubnetCount'), 1)]",
@@ -209,8 +210,10 @@
           "name": "[concat(parameters('gatewaySubnetNamePrefix'), '-', copyIndex('gatewaySubnetCopy'))]",
           "properties": {
             "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 0, copyIndex('gatewaySubnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
-            "serviceEndpoints": "[if(greater(length(parameters('serviceEndpointList')), 0), variables('serviceEndpoints'), variables('serviceEndpointsEmpty'))]",
-            "networkSecurityGroup": "[if(and(not(bool(equals(parameters('firewallsNsgName'),'Disabled'))), bool(equals(copyIndex('gatewaySubnetCopy'), 0))), variables('firewallNsgId'), json('null'))]"
+            "serviceEndpointList": "[parameters('serviceEndpointList')]",
+            "delegations": "[variables('emptyArray')]",
+            "networkSecurityGroup": "[if(and(not(bool(equals(parameters('firewallsNsgName'),'Disabled'))), bool(equals(copyIndex('gatewaySubnetCopy'), 0))), variables('firewallNsgId'), json('null'))]",
+            "routeTable": "[variables('emptyObject')]"
           }
         }
       },
@@ -221,6 +224,9 @@
           "name": "[concat(parameters('managementSubnetNamePrefix'), '-', copyIndex('managementSubnetCopy'))]",
           "properties": {
             "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 5, copyIndex('managementSubnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
+            "serviceEndpointList": "[variables('emptyArray')]",
+            "delegations": "[variables('emptyArray')]",
+            "networkSecurityGroup": "[variables('emptyObject')]",
             "routeTable": "[if(and(not(bool(equals(parameters('AKSRouteTableName'),'Disabled'))), bool(equals(copyIndex('managementSubnetCopy'), 0))), variables('aksRouteTableId'), json('null'))]"
           }
         }
@@ -232,8 +238,10 @@
           "name": "[concat(parameters('apimSubnetNamePrefix'), '-', copyIndex('apimSubnetCopy'))]",
           "properties": {
             "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 10, copyIndex('apimSubnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
-            "serviceEndpoints": "[if(greater(length(parameters('serviceEndpointList')), 0), variables('serviceEndpoints'), variables('serviceEndpointsEmpty'))]",
-            "networkSecurityGroup": "[if(and(not(bool(equals(parameters('apimNsgName'),'Disabled'))), bool(equals(copyIndex('apimSubnetCopy'), 0))), variables('apimNsgId'), json('null'))]"
+            "serviceEndpointList": "[parameters('serviceEndpointList')]",
+            "delegations": "[variables('emptyArray')]",
+            "networkSecurityGroup": "[if(and(not(bool(equals(parameters('apimNsgName'),'Disabled'))), bool(equals(copyIndex('apimSubnetCopy'), 0))), variables('apimNsgId'), json('null'))]",
+            "routeTable": "[variables('emptyObject')]"
           }
         }
       },
@@ -244,8 +252,10 @@
           "name": "[concat(parameters('frontendSubnetNamePrefix'), '-', copyIndex('frontendSubnetCopy'))]",
           "properties": {
             "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 15, copyIndex('frontendSubnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
-            "serviceEndpoints": "[if(greater(length(parameters('serviceEndpointList')), 0), variables('serviceEndpoints'), variables('serviceEndpointsEmpty'))]",
-            "delegations": "[variables('subnetDelegations')]"
+            "serviceEndpointList": "[parameters('serviceEndpointList')]",
+            "delegations": "[variables('subnetDelegations')]",
+            "networkSecurityGroup": "[variables('emptyObject')]",
+            "routeTable": "[variables('emptyObject')]"
           }
         }
       },
@@ -256,8 +266,10 @@
           "name": "[concat(parameters('backendSubnetNamePrefix'), '-', copyIndex('backendSubnetCopy'))]",
           "properties": {
             "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 20, copyIndex('backendSubnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
-            "serviceEndpoints": "[if(greater(length(parameters('serviceEndpointList')), 0), variables('serviceEndpoints'), variables('serviceEndpointsEmpty'))]",
-            "delegations": "[variables('subnetDelegations')]"
+            "serviceEndpointList": "[parameters('serviceEndpointList')]",
+            "delegations": "[variables('subnetDelegations')]",
+            "networkSecurityGroup": "[variables('emptyObject')]",
+            "routeTable": "[variables('emptyObject')]"
           }
         }
       },
@@ -268,14 +280,16 @@
           "name": "[concat(parameters('apimEndpointSubnetNamePrefix'), '-', copyIndex('apimEndpointSubnetCopy'))]",
           "properties": {
             "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 25, copyIndex('apimEndpointSubnetCopy'), parameters('subnetAddressSpaceCIDR'))]",
-            "serviceEndpoints": "[if(greater(length(parameters('serviceEndpointList')), 0), variables('serviceEndpoints'), variables('serviceEndpointsEmpty'))]",
-            "delegations": "[variables('subnetDelegations')]"
+            "serviceEndpointList": "[parameters('serviceEndpointList')]",
+            "delegations": "[variables('subnetDelegations')]",
+            "networkSecurityGroup": "[variables('emptyObject')]",
+            "routeTable": "[variables('emptyObject')]"
           }
         }
       }
     ],
-    "emptyArray": [
-    ],
+    "emptyArray": [],
+    "emptyObject": {},
     "gatewaySubnet": "[if(greater(parameters('gatewaySubnetCount'), 0), variables('gatewaySubnetCopy'), variables('emptyArray'))]",
     "apimSubnet": "[if(greater(parameters('apimSubnetCount'), 0), variables('apimSubnetCopy'), variables('emptyArray'))]",
     "frontendSubnet": "[if(greater(parameters('frontendSubnetCount'), 0), variables('frontendSubnetCopy'), variables('emptyArray'))]",
@@ -318,6 +332,7 @@
     {
       "apiVersion": "2017-05-10",
       "name": "virtual-network",
+      "condition": "[equals(parameters('virtualNetworkDeploy'), 'Enabled')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
@@ -331,18 +346,58 @@
           },
           "armVnetAddressSpaceCIDR": {
             "value": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 0, 0, parameters('virtualNetworkAddressSpaceCIDR'))]"
-          },
-          "subnetConfiguration": {
-            "value": "[variables('subnetConfiguration')]"
           }
         }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "[concat('subnet-', variables('subnetConfiguration')[copyIndex()].name)]",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": [
+        "virtual-network"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'subnet.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "virtualNetworkName": {
+            "value": "[parameters('virtualNetworkName')]"
+          },
+          "subnetName": {
+            "value": "[variables('subnetConfiguration')[copyIndex()].name]"
+          },
+          "subnetAddressPrefix": {
+            "value": "[variables('subnetConfiguration')[copyIndex()].properties.addressPrefix]"
+          },
+          "serviceEndpointList": {
+            "value": "[variables('subnetConfiguration')[copyIndex()].properties.serviceEndpointList]"
+          },
+          "delegations": {
+            "value": "[variables('subnetConfiguration')[copyIndex()].properties.delegations]"
+          },
+          "networkSecurityGroup": {
+            "value": "[if(empty(variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup), variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup, variables('emptyObject'))]"
+          },
+          "routeTable": {
+            "value": "[if(empty(variables('subnetConfiguration')[copyIndex()].properties.routeTable), variables('emptyObject'), variables('subnetConfiguration')[copyIndex()].properties.routeTable)]"
+          }
+        }
+      },
+      "copy": {
+        "name": "subnet-copy",
+        "count": "[length(variables('subnetConfiguration'))]",
+        "mode": "Serial"
       }
     }
   ],
   "outputs": {
-    "subnetConfiguration": {
+    "backendSubnetConfiguration": {
       "type": "array",
-      "value": "[skip(variables('subnetConfiguration'),2)]"
+      "value": "[variables('backendSubnet')]"
     }
   }
 }

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -380,7 +380,7 @@
             "value": "[variables('subnetConfiguration')[copyIndex()].properties.delegations]"
           },
           "networkSecurityGroup": {
-            "value": "[if(empty(variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup), variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup, variables('emptyObject'))]"
+            "value": "[if(empty(variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup), variables('emptyObject'), variables('subnetConfiguration')[copyIndex()].properties.networkSecurityGroup)]"
           },
           "routeTable": {
             "value": "[if(empty(variables('subnetConfiguration')[copyIndex()].properties.routeTable), variables('emptyObject'), variables('subnetConfiguration')[copyIndex()].properties.routeTable)]"

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -181,7 +181,7 @@
     }
   },
   "variables": {
-    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/separate-subnet-deployment/templates/",
+    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
     "aksRouteTableId": {
       "id": "[if(not(bool(equals(parameters('AKSRouteTableName'),'Disabled'))), resourceId(parameters('AKSRouteTableResourceGroupName'), 'Microsoft.Network/routeTables', parameters('AKSRouteTableName')),'')]"
     },

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -182,6 +182,8 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
+    "emptyArray": [],
+    "emptyObject": {},
     "aksRouteTableId": {
       "id": "[if(not(bool(equals(parameters('AKSRouteTableName'),'Disabled'))), resourceId(parameters('AKSRouteTableResourceGroupName'), 'Microsoft.Network/routeTables', parameters('AKSRouteTableName')),'')]"
     },
@@ -288,8 +290,6 @@
         }
       }
     ],
-    "emptyArray": [],
-    "emptyObject": {},
     "gatewaySubnet": "[if(greater(parameters('gatewaySubnetCount'), 0), variables('gatewaySubnetCopy'), variables('emptyArray'))]",
     "apimSubnet": "[if(greater(parameters('apimSubnetCount'), 0), variables('apimSubnetCopy'), variables('emptyArray'))]",
     "frontendSubnet": "[if(greater(parameters('frontendSubnetCount'), 0), variables('frontendSubnetCopy'), variables('emptyArray'))]",

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -344,7 +344,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/separate-subnet-deployment/",
+    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/master/",
     "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
     "loggingRedisCacheName": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-log-rds'))]",
     "keyVaultName": "[concat(variables('resourceNamePrefix'),'-kv')]",

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -124,6 +124,10 @@
     "virtualNetworkDeploy": {
       "type": "string",
       "defaultValue": "Disabled",
+      "allowedValues": [
+        "Disabled",
+        "Enabled"
+      ],
       "metadata": {
         "description": "Deploys the Virtual Network and deletes all subnets if Enabled https://github.com/Azure/azure-quickstart-templates/issues/2786",
         "environmentVariable": "virtualNetworkDeploy"

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -121,6 +121,14 @@
         "environmentVariable": "databaseConfiguration"
       }
     },
+    "virtualNetworkDeploy": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "metadata": {
+        "description": "Deploys the Virtual Network and deletes all subnets if Enabled https://github.com/Azure/azure-quickstart-templates/issues/2786",
+        "environmentVariable": "virtualNetworkDeploy"
+      }
+    },
     "gatewaySubnetCount": {
       "type": "int",
       "defaultValue": 0,
@@ -332,7 +340,7 @@
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/master/",
+    "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/separate-subnet-deployment/",
     "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
     "loggingRedisCacheName": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-log-rds'))]",
     "keyVaultName": "[concat(variables('resourceNamePrefix'),'-kv')]",
@@ -470,6 +478,9 @@
         "parameters": {
           "virtualNetworkName": {
             "value": "[variables('virtualNetworkName')]"
+          },
+          "virtualNetworkDeploy": {
+            "value": "[parameters('virtualNetworkDeploy')]"
           },
           "managementSubnetCount": {
             "value": "[variables('mgmtManagementSubnetCount')]"
@@ -626,6 +637,9 @@
           },
           "virtualNetworkAddressSpacePrefix": {
             "value": "[concat('10.', copyIndex(1))]"
+          },
+          "virtualNetworkDeploy": {
+            "value": "[parameters('virtualNetworkDeploy')]"
           },
           "gatewaySubnetCount": {
             "value": "[parameters('gatewaySubnetCount')]"

--- a/tests/modules/UnitTest.Helpers.psm1
+++ b/tests/modules/UnitTest.Helpers.psm1
@@ -15,6 +15,7 @@ function Set-MockEnvironment {
     $ENV:AKSRouteTableResourceGroupName = "Disabled"
     $ENV:firewallsNsgName = "Disabled"
     $ENV:backupManagementServiceObjectId = "fb0eac10-bda1-4410-9f8f-f4d381268d13"
+    $ENV:virtualNetworkDeploy = "Disabled"
     $ENV:gatewaySubnetCount = 1
     $ENV:apimSubnetCount = 1
     $ENV:frontendSubnetCount = 1
@@ -56,6 +57,7 @@ function Clear-MockEnvironment {
         "ENV:AKSRouteTableResourceGroupName",
         "ENV:firewallsNsgName",
         "ENV:backupManagementServiceObjectId",
+        "ENV:virtualNetworkDeploy"
         "ENV:gatewaySubnetCount",
         "ENV:apimSubnetCount",
         "ENV:frontendSubnetCount",

--- a/tests/resources/mock.template.json
+++ b/tests/resources/mock.template.json
@@ -135,6 +135,13 @@
         "environmentVariable": "databaseConfiguration"
       }
     },
+    "virtualNetworkDeploy": {
+      "type": "string",
+      "metadata": {
+        "description": "Deploys the Virtual Network and deletes all subnets if Enabled https://github.com/Azure/azure-quickstart-templates/issues/2786",
+        "environmentVariable": "virtualNetworkDeploy"
+      }
+    },
     "gatewaySubnetCount": {
       "type": "int",
       "defaultValue": 0,

--- a/tests/resources/mock.template.json
+++ b/tests/resources/mock.template.json
@@ -137,6 +137,11 @@
     },
     "virtualNetworkDeploy": {
       "type": "string",
+      "defaultValue": "Disabled",
+      "allowedValues": [
+        "Disabled",
+        "Enabled"
+      ],
       "metadata": {
         "description": "Deploys the Virtual Network and deletes all subnets if Enabled https://github.com/Azure/azure-quickstart-templates/issues/2786",
         "environmentVariable": "virtualNetworkDeploy"


### PR DESCRIPTION
Deployed shared subnets separately from virtual networks

- Added virtualNetworkDeploy parameter for conditional virtual network deployment so subnets are not deleted
- Deployed shared subnets in separate serial copy loop (Deployment conflict occurs if in parallel)
- Set SQL Server firewall rules allowing subnets to only backend subnets.

Function app/worker app service subnets within individual apps’ arm templates will be able to be deployed, not dependent on das-shared-infrastructure.