### PR TITLE
Failover group configuration generation fix

### DIFF
--- a/Initialize-SharedInfrastructureDeployment.ps1
+++ b/Initialize-SharedInfrastructureDeployment.ps1
@@ -76,9 +76,6 @@ try {
         $FailoverGroupBuilder = [FailoverGroupBuilder]::New()
         $ENV:DatabaseConfiguration = $FailoverGroupBuilder.CreateFailoverGroupConfig($ParsedEnvironmentNames)
     }
-    else {
-        $ENV:DatabaseConfiguration = $null
-    }
 
     # --- Create parameters file
     $ParametersFileBuilder = [ParametersFileBuilder]::New()

--- a/Initialize-SharedInfrastructureDeployment.ps1
+++ b/Initialize-SharedInfrastructureDeployment.ps1
@@ -72,7 +72,7 @@ try {
     $null = $ResourceGroupBuilder.CreateResourceGroups($SubscriptionAbbreviation, $ParsedEnvironmentNames, $Location, $Tags)
 
     # --- Create failover group configuration
-    if ( "PP", "PRD" -contains $ParsedEnvironmentNames ) {
+    if ( "DTA", "PP", "PRD" -contains $ParsedEnvironmentNames ) {
         $FailoverGroupBuilder = [FailoverGroupBuilder]::New()
         $ENV:DatabaseConfiguration = $FailoverGroupBuilder.CreateFailoverGroupConfig($ParsedEnvironmentNames)
     }

--- a/Initialize-SharedInfrastructureDeployment.ps1
+++ b/Initialize-SharedInfrastructureDeployment.ps1
@@ -72,8 +72,13 @@ try {
     $null = $ResourceGroupBuilder.CreateResourceGroups($SubscriptionAbbreviation, $ParsedEnvironmentNames, $Location, $Tags)
 
     # --- Create failover group configuration
-    $FailoverGroupBuilder = [FailoverGroupBuilder]::New()
-    $ENV:DatabaseConfiguration = $FailoverGroupBuilder.CreateFailoverGroupConfig($ParsedEnvironmentNames)
+    if ( "PP", "PRD" -contains $ParsedEnvironmentNames ) {
+        $FailoverGroupBuilder = [FailoverGroupBuilder]::New()
+        $ENV:DatabaseConfiguration = $FailoverGroupBuilder.CreateFailoverGroupConfig($ParsedEnvironmentNames)
+    }
+    else {
+        [Hashtable]$ENV:DatabaseConfiguration = @{ }
+    }
 
     # --- Create parameters file
     $ParametersFileBuilder = [ParametersFileBuilder]::New()

--- a/Initialize-SharedInfrastructureDeployment.ps1
+++ b/Initialize-SharedInfrastructureDeployment.ps1
@@ -77,7 +77,7 @@ try {
         $ENV:DatabaseConfiguration = $FailoverGroupBuilder.CreateFailoverGroupConfig($ParsedEnvironmentNames)
     }
     else {
-        [Hashtable]$ENV:DatabaseConfiguration = @{ }
+        $ENV:DatabaseConfiguration = $null
     }
 
     # --- Create parameters file

--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -52,6 +52,7 @@
     },
     "databaseConfiguration": {
       "type": "object",
+      "defaultValue": {},
       "metadata": {
         "description": "Configuration object which describes the structure of failovergroups"
       }

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -116,6 +116,7 @@
     },
     "databaseConfiguration": {
       "type": "object",
+      "defaultValue": {},
       "metadata": {
         "description": "Configuration object which describes the structure of failover groups",
         "environmentVariable": "databaseConfiguration"

--- a/tests/resources/mock.template.json
+++ b/tests/resources/mock.template.json
@@ -130,6 +130,7 @@
     },
     "databaseConfiguration": {
       "type": "object",
+      "defaultValue": {},
       "metadata": {
         "description": "Configuration object which describes the structure of failover groups",
         "environmentVariable": "databaseConfiguration"


### PR DESCRIPTION
Failover group configuration generation fix

- The Error 'Environment variable name or value is too long.' occurred when setting the $ENV:DatabaseConfiguration value for the DEV subscription in Initialize-SharedInfrastructureDeployment.ps1

- As the variable is only used in PP/PRD and DTA (for unit tests) , it does not need to be created if not PP/PRD/DTA and a defaultValue of an empty object can be set for the databaseConfiguration ARM template parameter.