### PR TITLE
Dasd 9204 Move agent pool for build off legacy deployment agent pool to Windows Build Agent

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,15 +9,24 @@ pr: none
 workspace:
   clean: all
 
+resources:
+repositories:
+- repository: self
+- repository: das-platform-building-blocks
+  type: github
+  name: SkillsFundingAgency/das-platform-building-blocks
+  ref: refs/tags/0.4.14
+  endpoint: SkillsFundingAgency
+
 pool:
-  name: "DAS - Continuous Deployment"
+  name: DAS - Continuous Integration Agents
   demands:
     - npm
     - node.js
+    - LATEST_DOTNET_VERSION -equals 3.1
 
 steps:
-  - task: gittools.gitversion.gitversion-task.GitVersion@5
-    displayName: GitVersion
+  - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
   - script: |
       npm install eclint
       node ./node_modules/eclint/bin/eclint.js check

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,11 +19,12 @@ resources:
     endpoint: SkillsFundingAgency
 
 pool:
-  name: DAS - Continuous Integration Agents
+  name: DAS - Continuous Integration
   demands:
     - npm
     - node.js
     - LATEST_DOTNET_VERSION -equals 3.1
+    - Agent.OS -equals Windows_NT
 
 steps:
   - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,13 +10,13 @@ workspace:
   clean: all
 
 resources:
-repositories:
-- repository: self
-- repository: das-platform-building-blocks
-  type: github
-  name: SkillsFundingAgency/das-platform-building-blocks
-  ref: refs/tags/0.4.14
-  endpoint: SkillsFundingAgency
+  repositories:
+  - repository: self
+  - repository: das-platform-building-blocks
+    type: github
+    name: SkillsFundingAgency/das-platform-building-blocks
+    ref: refs/tags/0.4.14
+    endpoint: SkillsFundingAgency
 
 pool:
   name: DAS - Continuous Integration Agents


### PR DESCRIPTION
- `node ./node_modules/eclint/bin/eclint.js check` fails on Linux build agent https://github.com/SkillsFundingAgency/das-azure-pipelines-agents/tree/master/Linux/Ubuntu-20/Build with error `Cannot find module '/azp/agent/_work/1/s/node_modules/eclint/bin/eclint.js'`
 - Successful on Windows Build Agent https://github.com/SkillsFundingAgency/das-azure-pipelines-agents/tree/master/Windows/Build