### PR TITLE
key vault: removed disk encryption access and restricted network access to trusted MSFT services

### DIFF
--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -410,13 +410,13 @@
           "keyVaultAccessPolicies": {
             "value": "[concat(variables('KeyVaultAccessPolicies'),variables('keyVaultGetAccessPoliciesCopy'),variables('keyVaultGetListAccessPoliciesCopy'))]"
           },
-          "enabledForDiskEncryption": {
-            "value": true
-          },
           "enabledForTemplateDeployment": {
             "value": true
           },
-          "enableSoftDelete": {
+          "enableFirewall": {
+            "value": true
+          },
+          "allowTrustedMicrosoftServices": {
             "value": true
           },
           "logAnalyticsWorkspaceName": {


### PR DESCRIPTION
key vault:

- removed disk encryption access policy
- restricted network access to trusted MSFT services https://docs.microsoft.com/en-us/azure/key-vault/general/overview-vnet-service-endpoints#trusted-services
- removed unneeded enableSoftDelete parameter