### PR TITLE
Update schema and add ASP customisation

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "environmentName": {

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "virtualNetworkName": {

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "resourceEnvironmentName": {
@@ -164,36 +164,26 @@
     "frontEndAppServicePlanSku": {
       "type": "object",
       "defaultValue": {
-        "tier": "Standard",
-        "size": "2",
-        "instances": 2
       },
       "metadata": {
-        "description": "An object representing the sku of the app service plan.",
+        "description": "An object representing the sku of the app service plan(s).",
         "environmentVariable": "frontEndAppServicePlanSku"
       }
     },
     "backEndAppServicePlanSku": {
       "type": "object",
       "defaultValue": {
-        "tier": "Standard",
-        "size": "2",
-        "instances": 2
       },
       "metadata": {
-        "description": "An object representing the sku of the app service plan.",
+        "description": "An object representing the sku of the app service plan(s).",
         "environmentVariable": "backEndAppServicePlanSku"
       }
     },
     "sharedWorkerAppServicePlanSku": {
       "type": "object",
-      "defaultValue": {
-        "tier": "Standard",
-        "size": "1",
-        "instances": 1
-      },
+      "defaultValue": {},
       "metadata": {
-        "description": "An object representing the sku of the app service plan.",
+        "description": "An object representing the sku of the app service plan(s).",
         "environmentVariable": "sharedWorkerAppServicePlanSku"
       }
     },
@@ -605,13 +595,13 @@
             "value": "[parameters('firewallsNsgName')]"
           },
           "frontEndAppServicePlanSku": {
-            "value": "[parameters('frontEndAppServicePlanSku')]"
+            "value": "[parameters('frontEndAppServicePlanSku')[toUpper(parameters('environments')[copyIndex()])]]"
           },
           "backEndAppServicePlanSku": {
-            "value": "[parameters('backEndAppServicePlanSku')]"
+            "value": "[parameters('backEndAppServicePlanSku')[toUpper(parameters('environments')[copyIndex()])]]"
           },
           "sharedWorkerAppServicePlanSku": {
-            "value": "[parameters('sharedWorkerAppServicePlanSku')]"
+            "value": "[parameters('sharedWorkerAppServicePlanSku')[toUpper(parameters('environments')[copyIndex()])]]"
           },
           "sharedStorageAccountContainerArray": {
             "value": "[parameters('sharedStorageAccountContainerArray')]"


### PR DESCRIPTION
## Context

Not all the ASP's in our Dev/Test environment which is created using a copy of a list of environment names where each ASP uses the same default are the same service tier. We need a way to configure each environments ASP to a different tier.

## Changes proposed in this pull request

- Update the template schema
- Remove the defaultValue for the ASP SKU parameter as these would not longer be valid and are always specified anyway.
- Read the ASP SKU from the SKU parameter object where it is passed in as a variable of the form: `{
    "environmentName": {
        "tier": "Free",
        "size": "1",
        "instances": 1
    }
}`

## Guidance to review

Tested deployment in to DTA

## Next Steps

- [x] Update the das-shared-infrastructure project ASP SKU variables to support the new format before merging