### PR TITLE
DASD-10547 - Add private endpoint to shared Redis

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -114,7 +114,15 @@
       "defaultValue": 1,
       "maxValue": 1,
       "metadata": {
-        "description": "The number of shared sql server subnets to provision."
+        "description": "Whether to deploy the shared AI search subnet."
+      }
+    },
+    "sharedRedisSubnetCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "maxValue": 1,
+      "metadata": {
+        "description": "Whether to deploy the shared redis subnet."
       }
     },
     "firewallsNsgName": {
@@ -206,6 +214,7 @@
     "eventHubNamespaceName": "[concat(variables('resourceNamePrefix'),'-eh')]",
     "aiSearchName": "[concat(variables('resourceNamePrefix'),'-srch')]",
     "aiSearchPrivateDnsZoneName": "privatelink.search.windows.net",
+    "sharedRedisPrivateDnsZoneName": "privatelink.redis.cache.windows.net",
     "configurationStorageName": "[concat(replace(variables('resourceNamePrefix'), '-',''), 'configstr')]",
     "sharedARMStorageName": "[concat(replace(variables('resourceNamePrefix'), '-',''), 'str')]",
     "sqlServerLocationMap": {
@@ -273,6 +282,9 @@
           },
           "sharedAiSearchSubnetCount": {
             "value": "[parameters('sharedAiSearchSubnetCount')]"
+          },
+          "sharedRedisSubnetCount": {
+            "value": "[parameters('sharedRedisSubnetCount')]"
           },
           "firewallsNsgName": {
             "value": "[parameters('firewallsNsgName')]"
@@ -791,6 +803,95 @@
       "dependsOn": [
         "[concat('virtual-network-west-europe-', variables('environmentName'))]",
         "ai-search-private-dns-zone"
+      ]
+    },
+    {
+      "apiVersion": "2020-08-01",
+      "name": "shared-redis-private-dns-zone",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'private-dns-zone.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "dnsZoneName": {
+            "value": "[variables('sharedRedisPrivateDnsZoneName')]"
+          },
+          "vnetId": {
+            "value": "[resourceId(resourceGroup().name, 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[concat('virtual-network-west-europe-', variables('environmentName'))]"
+      ]
+    },
+    {
+      "apiVersion": "2020-08-01",
+      "name": "shared-redis-private-endpoint",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'private-endpoint.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "privateEndpointName": {
+            "value": "[concat(variables('redisCacheName'),'-pe')]"
+          },
+          "subnetId": {
+            "value": "[reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.sharedRedisSubnetResourceId.value]"
+          },
+          "privateLinkGroupIds": {
+            "value": ["redisCache"]
+          },
+          "privateLinkServiceId": {
+            "value": "[resourceId(resourceGroup().name,'Microsoft.Cache/Redis',variables('redisCacheName'))]"
+          },
+          "privateDnsZoneId": {
+            "value": "[resourceId(resourceGroup().name,'Microsoft.Network/privateDnsZones',variables('sharedRedisPrivateDnsZoneName'))]"
+          }
+        }
+      },
+      "dependsOn": [
+        "[concat('virtual-network-west-europe-', variables('environmentName'))]",
+        "shared-redis-private-dns-zone",
+        "redis-cache"
+      ]
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "redis-cache-reset-public-access",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'redis.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "redisCacheName": {
+            "value": "[variables('redisCacheName')]"
+          },
+          "redisCacheSKU": {
+            "value": "Standard"
+          },
+          "redisCacheFamily": {
+            "value": "C"
+          },
+          "redisCacheCapacity": {
+            "value": 1
+          },
+          "enableNonSslPort": {
+            "value": false
+          }
+        }
+      },
+      "dependsOn": [
+        "shared-redis-private-endpoint"
       ]
     }
   ],

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -130,6 +130,21 @@
         "description": "The number of shared ai search subnets to provision."
       }
     },
+    "sharedRedisSubnetNamePrefix": {
+      "type": "string",
+      "defaultValue": "sharedrds-sn",
+      "metadata": {
+        "description": "The prefix used for naming new shared redis cache subnets."
+      }
+    },
+    "sharedRedisSubnetCount": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1,
+      "metadata": {
+        "description": "The number of shared redis cache subnets to provision."
+      }
+    },
     "serviceEndpointList": {
       "type": "array",
       "defaultValue": [],
@@ -252,12 +267,23 @@
         "routeTable": "[variables('emptyObject')]"
       }
     },
+    "sharedRedisSubnetObject": {
+      "name": "[parameters('sharedRedisSubnetNamePrefix')]",
+      "properties": {
+        "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 38, 0, parameters('subnetAddressSpaceCIDR'))]",
+        "serviceEndpointList": "[variables('emptyArray')]",
+        "delegations": "[variables('emptyArray')]",
+        "networkSecurityGroup": "[variables('emptyObject')]",
+        "routeTable": "[variables('emptyObject')]"
+      }
+    },
     "gatewaySubnet": "[if(greater(parameters('gatewaySubnetCount'), 0), variables('gatewaySubnetCopy'), variables('emptyArray'))]",
     "frontendSubnet": "[if(greater(parameters('frontendSubnetCount'), 0), variables('frontendSubnetCopy'), variables('emptyArray'))]",
     "backendSubnet": "[if(greater(parameters('backendSubnetCount'), 0), variables('backendSubnetCopy'), variables('emptyArray'))]",
     "sharedWorkerSubnet": "[if(greater(parameters('sharedWorkerSubnetCount'), 0), variables('sharedWorkerSubnetCopy'), variables('emptyArray'))]",
     "sharedAiSearchSubnet": "[if(greater(parameters('sharedAiSearchSubnetCount'), 0), array(variables('sharedAiSearchSubnetObject')), variables('emptyArray'))]",
-    "subnetConfiguration": "[concat(variables('managementSubnetCopy'), variables('gatewaySubnet'), variables('frontendSubnet'), variables('backendSubnet'), variables('sharedWorkerSubnet'), variables('sharedAiSearchSubnet'))]"
+    "sharedRedisSubnet": "[if(greater(parameters('sharedRedisSubnetCount'), 0), array(variables('sharedRedisSubnetObject')), variables('emptyArray'))]",
+    "subnetConfiguration": "[concat(variables('managementSubnetCopy'), variables('gatewaySubnet'), variables('frontendSubnet'), variables('backendSubnet'), variables('sharedWorkerSubnet'), variables('sharedAiSearchSubnet'), variables('sharedRedisSubnet'))]"
   },
   "functions": [
     {
@@ -368,6 +394,10 @@
     "sharedAiSearchSubnetResourceId": {
       "type": "string",
       "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'),variables('sharedAiSearchSubnetObject').name)]"
+    },
+    "sharedRedisSubnetResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'),variables('sharedRedisSubnetObject').name)]"
     }
   }
 }

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -451,6 +451,47 @@
           "allowedIpAddressesList": {
             "value": "[parameters('keyVaultAllowedIpAddressesList')]"
           },
+          "allowTrustedMicrosoftServices": {
+            "value": true
+          },
+          "logAnalyticsWorkspaceName": {
+            "value": "[parameters('logAnalyticsWorkspaceName')]"
+          },
+          "logAnalyticsWorkspaceResourceGroupName": {
+            "value": "[resourceGroup().name]"
+          }
+        }
+      },
+      "dependsOn": [
+        "log-analytics-workspace"
+      ]
+    },
+    {
+      "apiVersion": "2019-05-10",
+      "name": "key-vault-vnet-acl",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'keyvault.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "keyVaultName": {
+            "value": "[variables('keyVaultName')]"
+          },
+          "keyVaultAccessPolicies": {
+            "value": "[concat(variables('KeyVaultAccessPolicies'),variables('keyVaultGetAccessPoliciesCopy'),variables('keyVaultGetListAccessPoliciesCopy'))]"
+          },
+          "enabledForTemplateDeployment": {
+            "value": true
+          },
+          "enableFirewall": {
+            "value": true
+          },
+          "allowedIpAddressesList": {
+            "value": "[parameters('keyVaultAllowedIpAddressesList')]"
+          },
           "subnetResourceIdList": {
             "value": "[variables('keyVaultAllowedSubnetsArray')]"
           },
@@ -466,7 +507,8 @@
         }
       },
       "dependsOn": [
-        "log-analytics-workspace"
+        "log-analytics-workspace",
+        "environmentCopy"
       ]
     },
     {


### PR DESCRIPTION
## Context

We need to move traffic for various resources in the service to the virtual network. This change adds a private endpoint for the shared Azure Cache for Redis which will move communication from a public to private IP address and also remove the requirement for any SNAT ports being used for this service.

## Impact

Adding a private endpoint to the Azure Cache for Redis will have the following impacts
- Portal console will no longer be supported
- When adding the private endpoint the publicNetworkAccess property is toggled. There is a secondary deployment which returns this property to its original value. Access between these deployments may be unsuccessful.

## Changes proposed in this pull request

- Add shared Redis private endpoint deployment
- Add Redis private dns zone deployment
- Add new shared Redis subnet to virtual network
- Add additional Redis deployment to reset publicNetworkAccess property
- Fix Key Vault dependency by adding second deployment to set networkACL property

## Guidance to review

- [x] Confirm private endpoint has been added to the `das-dta-shared-rds` resource
- [x] Create a virtual network connected App Service on one of the shared App Service Plans and confirm the `nameresolver das-dta-shared-rds.redis.cache.windows.net` resolves to an internal IP
- [x] Check the branch/PR has deployed successfully in the das-shared-infrastructure release (Shared-Infrastructure-Deployment-633)