### PR TITLE
DASD-10568 Add private endpoint to logging Redis

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -125,6 +125,14 @@
         "description": "Whether to deploy the shared redis subnet."
       }
     },
+    "loggingRedisSubnetCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "maxValue": 1,
+      "metadata": {
+        "description": "Whether to deploy the shared redis subnet."
+      }
+    },
     "firewallsNsgName": {
       "type": "string",
       "defaultValue": "Disabled",
@@ -214,7 +222,8 @@
     "eventHubNamespaceName": "[concat(variables('resourceNamePrefix'),'-eh')]",
     "aiSearchName": "[concat(variables('resourceNamePrefix'),'-srch')]",
     "aiSearchPrivateDnsZoneName": "privatelink.search.windows.net",
-    "sharedRedisPrivateDnsZoneName": "privatelink.redis.cache.windows.net",
+    "redisPrivateDnsZoneName": "privatelink.redis.cache.windows.net",
+    "redisPrivateDnsZoneId": "[resourceId(resourceGroup().name,'Microsoft.Network/privateDnsZones',variables('redisPrivateDnsZoneName'))]",
     "configurationStorageName": "[concat(replace(variables('resourceNamePrefix'), '-',''), 'configstr')]",
     "sharedARMStorageName": "[concat(replace(variables('resourceNamePrefix'), '-',''), 'str')]",
     "sqlServerLocationMap": {
@@ -285,6 +294,9 @@
           },
           "sharedRedisSubnetCount": {
             "value": "[parameters('sharedRedisSubnetCount')]"
+          },
+          "loggingRedisSubnetCount": {
+            "value": "[parameters('loggingRedisSubnetCount')]"
           },
           "firewallsNsgName": {
             "value": "[parameters('firewallsNsgName')]"
@@ -807,7 +819,7 @@
     },
     {
       "apiVersion": "2020-08-01",
-      "name": "shared-redis-private-dns-zone",
+      "name": "redis-private-dns-zone",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
@@ -817,7 +829,7 @@
         },
         "parameters": {
           "dnsZoneName": {
-            "value": "[variables('sharedRedisPrivateDnsZoneName')]"
+            "value": "[variables('redisPrivateDnsZoneName')]"
           },
           "vnetId": {
             "value": "[resourceId(resourceGroup().name, 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
@@ -852,13 +864,13 @@
             "value": "[resourceId(resourceGroup().name,'Microsoft.Cache/Redis',variables('redisCacheName'))]"
           },
           "privateDnsZoneId": {
-            "value": "[resourceId(resourceGroup().name,'Microsoft.Network/privateDnsZones',variables('sharedRedisPrivateDnsZoneName'))]"
+            "value": "[variables('redisPrivateDnsZoneId')]"
           }
         }
       },
       "dependsOn": [
         "[concat('virtual-network-west-europe-', variables('environmentName'))]",
-        "shared-redis-private-dns-zone",
+        "redis-private-dns-zone",
         "redis-cache"
       ]
     },
@@ -895,5 +907,18 @@
       ]
     }
   ],
-  "outputs": {}
+  "outputs": {
+    "sharedResourceGroupName": {
+      "type": "string",
+      "value": "[resourceGroup().name]"
+    },
+    "loggingRedisSubnetResourceId": {
+      "type": "string",
+      "value": "[reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.loggingRedisSubnetResourceId.value]"
+    },
+    "redisPrivateDnsZoneId": {
+      "type": "string",
+      "value": "[variables('redisPrivateDnsZoneId')]"
+    }
+  }
 }

--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -72,6 +72,7 @@
     "gatewaySubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "The number of gateway subnets to provision"
@@ -80,6 +81,7 @@
     "managementSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "The number of management subnets to provision"
@@ -88,6 +90,7 @@
     "frontendSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared frontend app subnets to provision."
@@ -96,6 +99,7 @@
     "backendSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared backend app subnets to provision."
@@ -104,6 +108,7 @@
     "sharedWorkerSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared worker app subnets to provision."
@@ -112,6 +117,7 @@
     "sharedAiSearchSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "Whether to deploy the shared AI search subnet."
@@ -120,6 +126,7 @@
     "sharedRedisSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "Whether to deploy the shared redis subnet."
@@ -128,6 +135,7 @@
     "loggingRedisSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "Whether to deploy the shared redis subnet."
@@ -212,6 +220,7 @@
     "sharedDeploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-shared-infrastructure/master/",
     "environmentName": "[toLower(parameters('environmentName'))]",
     "resourceNamePrefix": "[toLower(concat('das-', variables('environmentName'),'-shared'))]",
+    "resourceGroupName": "[resourceGroup().name]",
     "sharedFrontEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'fe-asp')]",
     "sharedBackEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'be-asp')]",
     "sharedWorkerAppServicePlanName": "[concat(variables('resourceNamePrefix'),'wkr-asp')]",
@@ -223,7 +232,7 @@
     "aiSearchName": "[concat(variables('resourceNamePrefix'),'-srch')]",
     "aiSearchPrivateDnsZoneName": "privatelink.search.windows.net",
     "redisPrivateDnsZoneName": "privatelink.redis.cache.windows.net",
-    "redisPrivateDnsZoneId": "[resourceId(resourceGroup().name,'Microsoft.Network/privateDnsZones',variables('redisPrivateDnsZoneName'))]",
+    "redisPrivateDnsZoneId": "[resourceId(variables('resourceGroupName'),'Microsoft.Network/privateDnsZones',variables('redisPrivateDnsZoneName'))]",
     "configurationStorageName": "[concat(replace(variables('resourceNamePrefix'), '-',''), 'configstr')]",
     "sharedARMStorageName": "[concat(replace(variables('resourceNamePrefix'), '-',''), 'str')]",
     "sqlServerLocationMap": {
@@ -242,6 +251,7 @@
     "primarySQLServerName": "[toLower(concat(variables('baseSQLServerName'), '-', variables('sqlServerLocationMap').primary.nameSuffix))]",
     "secondarySQLServerName": "[toLower(concat(variables('baseSQLServerName'), '-', variables('sqlServerLocationMap').secondary.nameSuffix))]",
     "virtualNetworkName": "[concat(variables('resourceNamePrefix'),'-vnet')]",
+    "virtualNetworkDeploymentName": "[concat('virtual-network-west-europe-', variables('environmentName'))]",
     "subnetServiceEndpointList": [
       "Microsoft.Web",
       "Microsoft.Sql",
@@ -252,13 +262,13 @@
   },
   "resources": [
     {
-      "apiVersion": "2017-05-10",
-      "name": "[concat('virtual-network-west-europe-', variables('environmentName'))]",
+      "apiVersion": "2022-09-01",
+      "name": "[variables('virtualNetworkDeploymentName')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('sharedDeploymentUrlBase'),'templates/network.template.json')]",
+          "uri": "[uri(variables('sharedDeploymentUrlBase'),'templates/network.template.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -308,13 +318,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "get-subnet-resourceid-list",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('sharedDeploymentUrlBase'),'utilities/getSubnetResourceIdList.json')]",
+          "uri": "[uri(variables('sharedDeploymentUrlBase'),'utilities/getSubnetResourceIdList.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -322,19 +332,19 @@
             "value": "[variables('virtualNetworkName')]"
           },
           "subnetConfiguration": {
-            "value": "[concat(reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.backendSubnetConfiguration.value, reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.frontendSubnetConfiguration.value)]"
+            "value": "[concat(reference(variables('virtualNetworkDeploymentName')).outputs.backendSubnetConfiguration.value, reference(variables('virtualNetworkDeploymentName')).outputs.frontendSubnetConfiguration.value)]"
           }
         }
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "configuration-storage-account",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'storage-account-arm.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'storage-account-arm.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -348,13 +358,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "arm-shared-storage",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'storage-account-arm.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'storage-account-arm.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -368,14 +378,14 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "[concat('shared-storage-account-container', parameters('sharedStorageAccountContainerArray')[copyIndex()])]",
       "type": "Microsoft.Resources/deployments",
       "condition": "[greater(length(parameters('sharedStorageAccountContainerArray')), 0)]",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'), 'storage-container.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'), 'storage-container.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -399,13 +409,13 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "sql-server-deployment",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'sql-server.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'sql-server.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -448,13 +458,13 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "sql-server-firewall-rule",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'sql-server-firewall-rules.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'sql-server-firewall-rules.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -471,14 +481,14 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "sql-server-deployment-replica",
       "type": "Microsoft.Resources/deployments",
       "condition": "[variables('deployFailoverGroups')]",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'sql-server.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'sql-server.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -521,14 +531,14 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "sql-server-failover-group",
       "type": "Microsoft.Resources/deployments",
       "condition": "[variables('deployFailoverGroups')]",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'sql-server-failover-group.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'sql-server-failover-group.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -552,13 +562,13 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "front-end-app-service-plan",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'app-service-plan.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -578,13 +588,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "back-end-app-service-plan",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'app-service-plan.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -604,13 +614,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "shared-worker-app-service-plan",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'app-service-plan.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -630,13 +640,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "service-bus",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'service-bus.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'service-bus.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -658,13 +668,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "redis-cache",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'redis.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'redis.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -687,13 +697,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "cdn-profile",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'cdn-profile.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'cdn-profile.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -707,13 +717,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "event-hub-namespace",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'event-hub-namespace.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'event-hub-namespace.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -736,13 +746,13 @@
       }
     },
     {
-      "apiVersion": "2020-08-01",
+      "apiVersion": "2022-09-01",
       "name": "ai-search",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'azure-search.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'azure-search.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -762,13 +772,13 @@
       }
     },
     {
-      "apiVersion": "2020-08-01",
+      "apiVersion": "2022-09-01",
       "name": "ai-search-private-dns-zone",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'private-dns-zone.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'private-dns-zone.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -776,22 +786,22 @@
             "value": "[variables('aiSearchPrivateDnsZoneName')]"
           },
           "vnetId": {
-            "value": "[resourceId(resourceGroup().name, 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            "value": "[resourceId(variables('resourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
           }
         }
       },
       "dependsOn": [
-        "[concat('virtual-network-west-europe-', variables('environmentName'))]"
+        "[variables('virtualNetworkDeploymentName')]"
       ]
     },
     {
-      "apiVersion": "2020-08-01",
+      "apiVersion": "2022-09-01",
       "name": "ai-search-private-endpoint",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'private-endpoint.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'private-endpoint.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -799,32 +809,32 @@
             "value": "[concat(variables('aiSearchName'),'-pe')]"
           },
           "subnetId": {
-            "value": "[reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.sharedAiSearchSubnetResourceId.value]"
+            "value": "[reference(variables('virtualNetworkDeploymentName')).outputs.sharedAiSearchSubnetResourceId.value]"
           },
           "privateLinkGroupIds": {
             "value": ["searchService"]
           },
           "privateLinkServiceId": {
-            "value": "[resourceId(resourceGroup().name,'Microsoft.Search/searchServices',variables('aiSearchName'))]"
+            "value": "[resourceId(variables('resourceGroupName'),'Microsoft.Search/searchServices',variables('aiSearchName'))]"
           },
           "privateDnsZoneId": {
-            "value": "[resourceId(resourceGroup().name,'Microsoft.Network/privateDnsZones',variables('aiSearchPrivateDnsZoneName'))]"
+            "value": "[resourceId(variables('resourceGroupName'),'Microsoft.Network/privateDnsZones',variables('aiSearchPrivateDnsZoneName'))]"
           }
         }
       },
       "dependsOn": [
-        "[concat('virtual-network-west-europe-', variables('environmentName'))]",
+        "[variables('virtualNetworkDeploymentName')]",
         "ai-search-private-dns-zone"
       ]
     },
     {
-      "apiVersion": "2020-08-01",
+      "apiVersion": "2022-09-01",
       "name": "redis-private-dns-zone",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'private-dns-zone.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'private-dns-zone.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -832,22 +842,22 @@
             "value": "[variables('redisPrivateDnsZoneName')]"
           },
           "vnetId": {
-            "value": "[resourceId(resourceGroup().name, 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+            "value": "[resourceId(variables('resourceGroupName'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
           }
         }
       },
       "dependsOn": [
-        "[concat('virtual-network-west-europe-', variables('environmentName'))]"
+        "[variables('virtualNetworkDeploymentName')]"
       ]
     },
     {
-      "apiVersion": "2020-08-01",
+      "apiVersion": "2022-09-01",
       "name": "shared-redis-private-endpoint",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'private-endpoint.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'private-endpoint.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -855,13 +865,13 @@
             "value": "[concat(variables('redisCacheName'),'-pe')]"
           },
           "subnetId": {
-            "value": "[reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.sharedRedisSubnetResourceId.value]"
+            "value": "[reference(variables('virtualNetworkDeploymentName')).outputs.sharedRedisSubnetResourceId.value]"
           },
           "privateLinkGroupIds": {
             "value": ["redisCache"]
           },
           "privateLinkServiceId": {
-            "value": "[resourceId(resourceGroup().name,'Microsoft.Cache/Redis',variables('redisCacheName'))]"
+            "value": "[resourceId(variables('resourceGroupName'),'Microsoft.Cache/Redis',variables('redisCacheName'))]"
           },
           "privateDnsZoneId": {
             "value": "[variables('redisPrivateDnsZoneId')]"
@@ -869,19 +879,19 @@
         }
       },
       "dependsOn": [
-        "[concat('virtual-network-west-europe-', variables('environmentName'))]",
+        "[variables('virtualNetworkDeploymentName')]",
         "redis-private-dns-zone",
         "redis-cache"
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "redis-cache-reset-public-access",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'redis.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'redis.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -910,11 +920,11 @@
   "outputs": {
     "sharedResourceGroupName": {
       "type": "string",
-      "value": "[resourceGroup().name]"
+      "value": "[variables('resourceGroupName')]"
     },
     "loggingRedisSubnetResourceId": {
       "type": "string",
-      "value": "[reference(concat('virtual-network-west-europe-', variables('environmentName'))).outputs.loggingRedisSubnetResourceId.value]"
+      "value": "[reference(variables('virtualNetworkDeploymentName')).outputs.loggingRedisSubnetResourceId.value]"
     },
     "redisPrivateDnsZoneId": {
       "type": "string",

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -145,6 +145,21 @@
         "description": "The number of shared redis cache subnets to provision."
       }
     },
+    "loggingRedisSubnetNamePrefix": {
+      "type": "string",
+      "defaultValue": "loggingrds-sn",
+      "metadata": {
+        "description": "The prefix used for naming new logging redis cache subnets."
+      }
+    },
+    "loggingRedisSubnetCount": {
+      "type": "int",
+      "defaultValue": 0,
+      "maxValue": 1,
+      "metadata": {
+        "description": "The number of logging redis cache subnets to provision."
+      }
+    },
     "serviceEndpointList": {
       "type": "array",
       "defaultValue": [],
@@ -277,13 +292,24 @@
         "routeTable": "[variables('emptyObject')]"
       }
     },
+    "loggingRedisSubnetObject": {
+      "name": "[parameters('loggingRedisSubnetNamePrefix')]",
+      "properties": {
+        "addressPrefix": "[blocks.getNextAddressRange(parameters('virtualNetworkAddressSpacePrefix'), 39, 0, parameters('subnetAddressSpaceCIDR'))]",
+        "serviceEndpointList": "[variables('emptyArray')]",
+        "delegations": "[variables('emptyArray')]",
+        "networkSecurityGroup": "[variables('emptyObject')]",
+        "routeTable": "[variables('emptyObject')]"
+      }
+    },
     "gatewaySubnet": "[if(greater(parameters('gatewaySubnetCount'), 0), variables('gatewaySubnetCopy'), variables('emptyArray'))]",
     "frontendSubnet": "[if(greater(parameters('frontendSubnetCount'), 0), variables('frontendSubnetCopy'), variables('emptyArray'))]",
     "backendSubnet": "[if(greater(parameters('backendSubnetCount'), 0), variables('backendSubnetCopy'), variables('emptyArray'))]",
     "sharedWorkerSubnet": "[if(greater(parameters('sharedWorkerSubnetCount'), 0), variables('sharedWorkerSubnetCopy'), variables('emptyArray'))]",
     "sharedAiSearchSubnet": "[if(greater(parameters('sharedAiSearchSubnetCount'), 0), array(variables('sharedAiSearchSubnetObject')), variables('emptyArray'))]",
     "sharedRedisSubnet": "[if(greater(parameters('sharedRedisSubnetCount'), 0), array(variables('sharedRedisSubnetObject')), variables('emptyArray'))]",
-    "subnetConfiguration": "[concat(variables('managementSubnetCopy'), variables('gatewaySubnet'), variables('frontendSubnet'), variables('backendSubnet'), variables('sharedWorkerSubnet'), variables('sharedAiSearchSubnet'), variables('sharedRedisSubnet'))]"
+    "loggingRedisSubnet": "[if(greater(parameters('loggingRedisSubnetCount'), 0), array(variables('loggingRedisSubnetObject')), variables('emptyArray'))]",
+    "subnetConfiguration": "[concat(variables('managementSubnetCopy'), variables('gatewaySubnet'), variables('frontendSubnet'), variables('backendSubnet'), variables('sharedWorkerSubnet'), variables('sharedAiSearchSubnet'), variables('sharedRedisSubnet'), variables('loggingRedisSubnet'))]"
   },
   "functions": [
     {
@@ -398,6 +424,10 @@
     "sharedRedisSubnetResourceId": {
       "type": "string",
       "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'),variables('sharedRedisSubnetObject').name)]"
+    },
+    "loggingRedisSubnetResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'),variables('loggingRedisSubnetObject').name)]"
     }
   }
 }

--- a/templates/network.template.json
+++ b/templates/network.template.json
@@ -50,6 +50,7 @@
     "gatewaySubnetCount": {
       "type": "int",
       "defaultValue": 0,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of gateway subnets to provision"
@@ -65,6 +66,7 @@
     "managementSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of management subnets to provision"
@@ -80,6 +82,7 @@
     "frontendSubnetCount": {
       "type": "int",
       "defaultValue": 0,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared frontend app subnets to provision"
@@ -95,6 +98,7 @@
     "backendSubnetCount": {
       "type": "int",
       "defaultValue": 0,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared backend app subnets to provision."
@@ -110,6 +114,7 @@
     "sharedWorkerSubnetCount": {
       "type": "int",
       "defaultValue": 0,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared worker app subnets to provision."
@@ -125,6 +130,7 @@
     "sharedAiSearchSubnetCount": {
       "type": "int",
       "defaultValue": 0,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "The number of shared ai search subnets to provision."
@@ -140,6 +146,7 @@
     "sharedRedisSubnetCount": {
       "type": "int",
       "defaultValue": 0,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "The number of shared redis cache subnets to provision."
@@ -155,6 +162,7 @@
     "loggingRedisSubnetCount": {
       "type": "int",
       "defaultValue": 0,
+      "minValue": 0,
       "maxValue": 1,
       "metadata": {
         "description": "The number of logging redis cache subnets to provision."
@@ -344,14 +352,14 @@
   ],
   "resources": [
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "virtual-network",
       "condition": "[equals(parameters('virtualNetworkDeploy'), 'Enabled')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'virtual-network.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'virtual-network.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -365,7 +373,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "[concat('subnet-', variables('subnetConfiguration')[copyIndex()].name)]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -374,7 +382,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'subnet.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'subnet.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -112,6 +112,7 @@
     "gatewaySubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of gateway subnets to provision",
@@ -121,6 +122,7 @@
     "managementSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 50,
       "metadata": {
         "description": "The number of management subnets to provision",
@@ -130,6 +132,7 @@
     "frontendSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared frontend app subnets to provision.",
@@ -139,6 +142,7 @@
     "backendSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared backend app subnets to provision.",
@@ -148,6 +152,7 @@
     "sharedWorkerSubnetCount": {
       "type": "int",
       "defaultValue": 1,
+      "minValue": 0,
       "maxValue": 5,
       "metadata": {
         "description": "The number of shared worker app subnets to provision.",
@@ -278,7 +283,7 @@
     "automationAccountName": "[concat(variables('resourceNamePrefix'),'-aa')]",
     "mgmtManagementSubnetCount": 1,
     "virtualNetworkName": "[concat(variables('resourceNamePrefix'),'-vnet')]",
-    "redisPrivateDnsZoneName": "privatelink.redis.cache.windows.net",
+    "resourceGroupName": "[resourceGroup().name]",
     "keyVaultAccessPolicies": [
       {
         "objectId": "[parameters('microsoftAzureWebsitesRPObjectId')]",
@@ -401,13 +406,13 @@
   ],
   "resources": [
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "[concat('virtual-network-west-europe-', variables('resourceNamePrefix'))]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('sharedDeploymentUrlBase'),'templates/network.template.json')]",
+          "uri": "[uri(variables('sharedDeploymentUrlBase'),'templates/network.template.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -427,13 +432,13 @@
       }
     },
     {
-      "apiVersion": "2019-05-10",
+      "apiVersion": "2022-09-01",
       "name": "key-vault",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'keyvault.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'keyvault.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -459,7 +464,7 @@
             "value": "[parameters('logAnalyticsWorkspaceName')]"
           },
           "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[resourceGroup().name]"
+            "value": "[variables('resourceGroupName')]"
           }
         }
       },
@@ -468,13 +473,13 @@
       ]
     },
     {
-      "apiVersion": "2019-05-10",
+      "apiVersion": "2022-09-01",
       "name": "key-vault-vnet-acl",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'keyvault.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'keyvault.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -503,7 +508,7 @@
             "value": "[parameters('logAnalyticsWorkspaceName')]"
           },
           "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[resourceGroup().name]"
+            "value": "[variables('resourceGroupName')]"
           }
         }
       },
@@ -513,13 +518,13 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "[concat('sql-server-key-vault-secrets-', parameters('environments')[copyIndex()])]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'keyvault-secret.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'keyvault-secret.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -543,13 +548,13 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "log-analytics-workspace",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'log-analytics-workspace.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'log-analytics-workspace.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -566,13 +571,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "classic-storage-account",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'storage-account-classic.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'storage-account-classic.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -583,14 +588,14 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "[toLower(concat(parameters('environments')[copyIndex()], '-shared-environment-infrastructure'))]",
       "type": "Microsoft.Resources/deployments",
       "resourceGroup": "[toLower(concat('das-', parameters('environments')[copyIndex()], '-shared-rg'))]",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('sharedDeploymentUrlBase'), 'templates/environment.template.json')]",
+          "uri": "[uri(variables('sharedDeploymentUrlBase'), 'templates/environment.template.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -598,7 +603,7 @@
             "value": "[toUpper(parameters('environments')[copyIndex()])]"
           },
           "sharedManagementResourceGroup": {
-            "value": "[resourceGroup().name]"
+            "value": "[variables('resourceGroupName')]"
           },
           "sharedKeyVaultName": {
             "value": "[variables('keyVaultName')]"
@@ -664,7 +669,7 @@
             "value": "[parameters('logAnalyticsWorkspaceName')]"
           },
           "logAnalyticsWorkspaceResourceGroupName": {
-            "value": "[resourceGroup().name]"
+            "value": "[variables('resourceGroupName')]"
           }
         }
       },
@@ -679,13 +684,13 @@
       ]
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "azure-automation",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'automation-account.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'automation-account.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -696,13 +701,13 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "logging-redis-cache",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'redis.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'redis.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -725,7 +730,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "[toLower(concat(parameters('environments')[copyIndex()], '-logging-redis-private-endpoint'))]",
       "type": "Microsoft.Resources/deployments",
       "resourceGroup": "[toLower(concat('das-', parameters('environments')[copyIndex()], '-shared-rg'))]",
@@ -733,21 +738,21 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'private-endpoint.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'private-endpoint.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
           "privateEndpointName": {
-            "value": "[concat(variables('loggingRedisCacheName'), '-', toLower(parameters('environments')[copyIndex()]), '-pe')]"
+            "value": "[concat(variables('loggingRedisCacheName'), if(equals(toLower(parameters('resourceEnvironmentName')), 'dev'), concat( '-', toLower(parameters('environments')[copyIndex()])), ''), '-pe')]"
           },
           "subnetId": {
             "value": "[reference(toLower(concat(parameters('environments')[copyIndex()], '-shared-environment-infrastructure'))).outputs.loggingRedisSubnetResourceId.value]"
           },
           "privateLinkGroupIds": {
-            "value": ["redisCache"]
+            "value": [ "redisCache" ]
           },
           "privateLinkServiceId": {
-            "value": "[resourceId(resourceGroup().name, 'Microsoft.Cache/Redis', variables('loggingRedisCacheName'))]"
+            "value": "[resourceId(variables('resourceGroupName'), 'Microsoft.Cache/Redis', variables('loggingRedisCacheName'))]"
           },
           "privateDnsZoneId": {
             "value": "[reference(toLower(concat(parameters('environments')[copyIndex()], '-shared-environment-infrastructure'))).outputs.redisPrivateDnsZoneId.value]"
@@ -760,14 +765,14 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2022-09-01",
       "name": "logging-redis-cache-reset-public-access",
       "type": "Microsoft.Resources/deployments",
       "comments": "Toggles public access to it's original value as soon as the private endpoint deployment succeeds",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'),'redis.json')]",
+          "uri": "[uri(variables('deploymentUrlBase'),'redis.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -278,6 +278,7 @@
     "automationAccountName": "[concat(variables('resourceNamePrefix'),'-aa')]",
     "mgmtManagementSubnetCount": 1,
     "virtualNetworkName": "[concat(variables('resourceNamePrefix'),'-vnet')]",
+    "redisPrivateDnsZoneName": "privatelink.redis.cache.windows.net",
     "keyVaultAccessPolicies": [
       {
         "objectId": "[parameters('microsoftAzureWebsitesRPObjectId')]",
@@ -722,6 +723,74 @@
           }
         }
       }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "[toLower(concat(parameters('environments')[copyIndex()], '-logging-redis-private-endpoint'))]",
+      "type": "Microsoft.Resources/deployments",
+      "resourceGroup": "[toLower(concat('das-', parameters('environments')[copyIndex()], '-shared-rg'))]",
+      "comments": "Private endpoint added here instead of environment template to reduce time publicNetworkAccess is set to Disabled",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'private-endpoint.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "privateEndpointName": {
+            "value": "[concat(variables('loggingRedisCacheName'), '-', toLower(parameters('environments')[copyIndex()]), '-pe')]"
+          },
+          "subnetId": {
+            "value": "[reference(toLower(concat(parameters('environments')[copyIndex()], '-shared-environment-infrastructure'))).outputs.loggingRedisSubnetResourceId.value]"
+          },
+          "privateLinkGroupIds": {
+            "value": ["redisCache"]
+          },
+          "privateLinkServiceId": {
+            "value": "[resourceId(resourceGroup().name, 'Microsoft.Cache/Redis', variables('loggingRedisCacheName'))]"
+          },
+          "privateDnsZoneId": {
+            "value": "[reference(toLower(concat(parameters('environments')[copyIndex()], '-shared-environment-infrastructure'))).outputs.redisPrivateDnsZoneId.value]"
+          }
+        }
+      },
+      "copy": {
+        "name": "loggingRedisPrivateEndpointCopy",
+        "count": "[length(parameters('environments'))]"
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "logging-redis-cache-reset-public-access",
+      "type": "Microsoft.Resources/deployments",
+      "comments": "Toggles public access to it's original value as soon as the private endpoint deployment succeeds",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'),'redis.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "redisCacheName": {
+            "value": "[variables('loggingRedisCacheName')]"
+          },
+          "redisCacheSKU": {
+            "value": "[parameters('loggingRedisCacheSKU')]"
+          },
+          "redisCacheFamily": {
+            "value": "[parameters('loggingRedisCacheFamily')]"
+          },
+          "redisCacheCapacity": {
+            "value": "[parameters('loggingRedisCacheCapacity')]"
+          },
+          "enableNonSslPort": {
+            "value": false
+          }
+        }
+      },
+      "dependsOn": [
+        "loggingRedisPrivateEndpointCopy"
+      ]
     }
   ],
   "outputs": {}


### PR DESCRIPTION
## Context

We need to move traffic for various resources in the service to the virtual network. This change adds a private endpoint for the logging Azure Cache for Redis which will move communication from a public to private IP address and also remove the requirement for any SNAT ports being used for this service.

## Impact

Adding a private endpoint to the Azure Cache for Redis will have the following impacts.
- Portal console will no longer be supported
- When adding the private endpoint there may be brief connectivity issues with the service. This is particularly true with Dev/Test where other environments will also continue to use the resource outside of the virtual network until their private endpoints are added. The publicNetworkAccess property is toggled to ensure these environments continue to be able to access the service. There is a secondary deployment which returns this property to its original value. Access between these deployments may be unsuccessful.

## Changes proposed in this pull request

- Add logging Redis private endpoint deployment
- Use existing Redis private DNS zone deployment in shared resource group
- Add new logging Redis subnet to virtual network
- Add additional Redis deployment to reset publicNetworkAccess property
- Tidy-up templates based on output from the ARM Template Toolkit (ARM TTK)

## Guidance to review

- [x] Confirm private endpoint has been added to the `das-dta-log-rds` resource
- [x] Create a virtual network connected App Service on one of the shared App Service Plans and confirm the `nameresolver das-dta-log-rds.redis.cache.windows.net` resolves to an internal IP
- [x] Check the branch/PR has deployed successfully in the das-shared-infrastructure release