### PR TITLE
Changed hard-coded values to parametrised values for shared redis

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -6,6 +6,26 @@
       "type": "string",
       "metadata": {
         "description": "Abbreviated name for the environment, eg: AT, TEST, PP, PRD"
+    },
+    "redisCacheSKU": {
+      "type": "string",
+      "defaultValue": "Standard"
+      "metadata": {
+        "description": "The type of Redis cache to deploy"
+      }
+    },
+    "redisCacheFamily": {
+      "type": "string",
+      "defaultValue": "C"
+      "metadata": {
+        "description": "The SKU family to use"
+      }
+    },
+    "redisCacheCapacity": {
+      "type": "int",
+      "defaultValue": 1
+      "metadata": {
+        "description": "The size of the Redis cache to deploy"
       }
     },
     "sharedManagementResourceGroup": {
@@ -721,13 +741,13 @@
             "value": "[variables('sharedRedisCacheName')]"
           },
           "redisCacheSKU": {
-            "value": "Standard"
+              "value": "[parameters('redisCacheSKU')]"
           },
           "redisCacheFamily": {
-            "value": "C"
+              "value": "[parameters('redisCacheFamily')]"
           },
           "redisCacheCapacity": {
-            "value": 1
+              "value": "[parameters('redisCacheCapacity')]"
           },
           "enableNonSslPort": {
             "value": false

--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -741,13 +741,13 @@
             "value": "[variables('sharedRedisCacheName')]"
           },
           "redisCacheSKU": {
-              "value": "[parameters('redisCacheSKU')]"
+            "value": "[parameters('redisCacheSKU')]"
           },
           "redisCacheFamily": {
-              "value": "[parameters('redisCacheFamily')]"
+            "value": "[parameters('redisCacheFamily')]"
           },
           "redisCacheCapacity": {
-              "value": "[parameters('redisCacheCapacity')]"
+            "value": "[parameters('redisCacheCapacity')]"
           },
           "enableNonSslPort": {
             "value": false

--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -9,21 +9,21 @@
     },
     "redisCacheSKU": {
       "type": "string",
-      "defaultValue": "Standard"
+      "defaultValue": "Standard",
       "metadata": {
         "description": "The type of Redis cache to deploy"
       }
     },
     "redisCacheFamily": {
       "type": "string",
-      "defaultValue": "C"
+      "defaultValue": "C",
       "metadata": {
         "description": "The SKU family to use"
       }
     },
     "redisCacheCapacity": {
       "type": "int",
-      "defaultValue": 1
+      "defaultValue": 1,
       "metadata": {
         "description": "The size of the Redis cache to deploy"
       }

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -13,7 +13,7 @@
       "type": "string",
       "defaultValue": "Standard",
       "metadata": {
-        "description": "The type of Redis cache to deploy"
+        "description": "The type of Redis cache to deploy",
         "environmentVariable": "redisCacheSKU"
       }
     },
@@ -21,7 +21,7 @@
       "type": "string",
       "defaultValue": "C",
       "metadata": {
-        "description": "The SKU family to use"
+        "description": "The SKU family to use",
         "environmentVariable": "redisCacheFamily"
       }
     },

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -14,6 +14,7 @@
       "defaultValue": "Standard",
       "metadata": {
         "description": "The type of Redis cache to deploy"
+        "environmentVariable": "redisCacheSKU"
       }
     },
     "redisCacheFamily": {
@@ -21,6 +22,7 @@
       "defaultValue": "C",
       "metadata": {
         "description": "The SKU family to use"
+        "environmentVariable": "redisCacheFamily"
       }
     },
     "redisCacheCapacity": {

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -9,6 +9,28 @@
         "environmentVariable": "resourceEnvironmentName"
       }
     },
+    "redisCacheSKU": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "The type of Redis cache to deploy"
+      }
+    },
+    "redisCacheFamily": {
+      "type": "string",
+      "defaultValue": "C",
+      "metadata": {
+        "description": "The SKU family to use"
+      }
+    },
+    "redisCacheCapacity": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The size of the Redis cache to deploy",
+        "environmentVariable": "redisCacheCapacity"
+      }
+    },
     "serviceName": {
       "type": "string",
       "defaultValue": "shared",
@@ -617,6 +639,15 @@
         "parameters": {
           "environmentName": {
             "value": "[toUpper(parameters('environments')[copyIndex()])]"
+          },
+          "redisCacheSKU": {
+            "value": "[parameters('redisCacheSKU')]"
+          },
+          "redisCacheFamily": {
+            "value": "[parameters('redisCacheFamily')]"
+          },
+          "redisCacheCapacity": {
+            "value": "[parameters('redisCacheCapacity')]"
           },
           "sharedManagementResourceGroup": {
             "value": "[variables('resourceGroupName')]"


### PR DESCRIPTION
A recent period end issue required the tier of the shared Redis Cache to be increased from a C1 to a C2. Since [Shared-Infrastructure-Deployment-662](https://dev.azure.com/sfa-gov-uk/Apprenticeships%20Service%20Cloud%20Platform/_releaseProgress?_a=release-pipeline-progress&releaseId=30548) was deployed, the size of the shared Redis Cache was aligned to the ARM template value which is hard coded.

This needs to be updated so that it can be set based on a parameter. The default value for this parameter should be set to the most widely used tier, and then it can be overridden on a per environment basis.