### PR TITLE
Parameterised redis cache values to make passing in param values dynamic

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -8,6 +8,27 @@
         "description": "Abbreviated name for the environment, eg: AT, TEST, PP, PRD"
       }
     },
+    "sharedRedisCacheSKU": {
+        "type": "string",
+        "defaultValue": "Standard",
+        "metadata": {
+          "description": "The type of Redis cache to deploy"
+        }
+    },
+    "sharedRedisCacheFamily": {
+      "type": "string",
+      "defaultValue": "C",
+      "metadata": {
+        "description": "The SKU family to use"
+      }
+    },
+    "sharedRedisCacheCapacity": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The size of the Redis cache to deploy"
+      }
+    },
     "sharedManagementResourceGroup": {
       "type": "string",
       "metadata": {
@@ -721,13 +742,13 @@
             "value": "[variables('sharedRedisCacheName')]"
           },
           "redisCacheSKU": {
-            "value": "Standard"
+            "value": "[parameters('sharedRedisCacheSKU')]"
           },
           "redisCacheFamily": {
-            "value": "C"
+            "value": "[parameters('sharedRedisCacheFamily')]"
           },
           "redisCacheCapacity": {
-            "value": 1
+            "value": "[parameters('sharedRedisCacheCapacity')]"
           },
           "enableNonSslPort": {
             "value": false

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -9,6 +9,30 @@
         "environmentVariable": "resourceEnvironmentName"
       }
     },
+    "sharedRedisCacheSKU": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "The type of Redis cache to deploy",
+        "environmentVariable": "sharedRedisCacheSKU"
+      }
+    },
+    "sharedRedisCacheFamily": {
+      "type": "string",
+      "defaultValue": "C",
+      "metadata": {
+        "description": "The SKU family to use",
+        "environmentVariable": "sharedRedisCacheFamily"
+      }
+    },
+    "sharedRedisCacheCapacity": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The size of the Redis cache to deploy",
+        "environmentVariable": "sharedRedisCacheCapacity"
+      }
+    },
     "serviceName": {
       "type": "string",
       "defaultValue": "shared",
@@ -617,6 +641,15 @@
         "parameters": {
           "environmentName": {
             "value": "[toUpper(parameters('environments')[copyIndex()])]"
+          },
+          "sharedRedisCacheSKU": {
+            "value": "[parameters('sharedRedisCacheSKU')]"
+          },
+          "sharedRedisCacheFamily": {
+            "value": "[parameters('sharedRedisCacheFamily')]"
+          },
+          "sharedRedisCacheCapacity": {
+            "value": "[parameters('sharedRedisCacheCapacity')]"
           },
           "sharedManagementResourceGroup": {
             "value": "[variables('resourceGroupName')]"


### PR DESCRIPTION
A recent period end issue required the tier of the shared Redis Cache to be increased from a C1 to a C2. Since [Shared-Infrastructure-Deployment-662](https://dev.azure.com/sfa-gov-uk/Apprenticeships%20Service%20Cloud%20Platform/_releaseProgress?_a=release-pipeline-progress&releaseId=30548) was deployed, the size of the shared Redis Cache was aligned to the ARM template value which is hard coded.

This needs to be updated so that it can be set based on a parameter. The default value for this parameter should be set to the most widely used tier, and then it can be overridden on a per environment basis