### PR TITLE
Added backend app service plan deployment with copy loop for multiple ASP creation in the future

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -200,6 +200,13 @@
         "description": "An object representing the sku of the app service plan."
       }
     },
+    "backendAppServicePlanSkus": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Takes an array of objects: '[{\"identifier\": 0,\"tier\": \"Basic\",\"size\": \"1\",\"instances\": 1}]. Removing the backslash. The identifier helps map the values to the deployed ASP."
+      }
+    },
     "sharedWorkerAppServicePlanSku": {
       "type": "object",
       "defaultValue": {
@@ -265,6 +272,10 @@
       "metadata": {
         "description": "The pricing tier of the search service you want to create (for example, basic or standard)."
       }
+    },
+    "utcValue": {
+      "type": "string",
+      "defaultValue": "[utcNow()]"
     }
   },
   "variables": {
@@ -275,6 +286,7 @@
     "resourceGroupName": "[resourceGroup().name]",
     "sharedFrontEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'fe-asp')]",
     "sharedBackEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'be-asp')]",
+    "backEndAppServicePlanNamePrefix": "[concat(variables('resourceNamePrefix'), 'be-asp-')]",
     "sharedWorkerAppServicePlanName": "[concat(variables('resourceNamePrefix'),'wkr-asp')]",
     "firewallsResourceGroup": "[toLower(concat('das-', variables('environmentName'),'-firewall-rg'))]",
     "serviceBusNamespaceName": "[concat(variables('resourceNamePrefix'),'-ns')]",
@@ -669,6 +681,37 @@
           },
           "nonASETier": {
             "value": "[parameters('backEndAppServicePlanSku').tier]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[concat('back-end-app-service-plan-', copyIndex(), '-', parameters('utcValue'))]",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "copy": {
+        "name": "backendAppServicePlanLoop",
+        "count": "[length(parameters('backendAppServicePlanSkus'))]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[uri(variables('deploymentUrlBase'),'app-service-plan.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServicePlanName": {
+            "value": "[concat(variables('backEndAppServicePlanNamePrefix'), copyIndex())]"
+          },
+          "aspSize": {
+            "value": "[parameters('backendAppServicePlanSkus')[copyIndex()].size]"
+          },
+          "aspInstances": {
+            "value": "[parameters('backendAppServicePlanSkus')[copyIndex()].instances]"
+          },
+          "nonASETier": {
+            "value": "[parameters('backendAppServicePlanSkus')[copyIndex()].tier]"
           }
         }
       }

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -208,6 +208,14 @@
         "environmentVariable": "backEndAppServicePlanSku"
       }
     },
+    "backendAppServicePlanSkus": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Takes an array of objects: '[{\"identifier\": 0,\"tier\": \"Basic\", \"size\": \"1\",\"instances\": 1}]. Removing the backslash. The identifier helps map the values to the deployed ASP.",
+        "environmentVariable": "backendAppServicePlanSkus"
+      }
+    },
     "sharedWorkerAppServicePlanSku": {
       "type": "object",
       "defaultValue": {},
@@ -704,6 +712,9 @@
           },
           "backEndAppServicePlanSku": {
             "value": "[parameters('backEndAppServicePlanSku')[toUpper(parameters('environments')[copyIndex()])]]"
+          },
+          "backendAppServicePlanSkus": {
+            "value": "[parameters('backendAppServicePlanSkus')]"
           },
           "sharedWorkerAppServicePlanSku": {
             "value": "[parameters('sharedWorkerAppServicePlanSku')[toUpper(parameters('environments')[copyIndex()])]]"

--- a/tests/modules/UnitTest.Helpers.psm1
+++ b/tests/modules/UnitTest.Helpers.psm1
@@ -19,6 +19,7 @@ function Set-MockEnvironment {
     $ENV:sharedWorkerSubnetCount = 1
     $ENV:sqlAdminPasswordSeed = "test seed"
     $ENV:DatabaseConfiguration = "{}"
+    $ENV:backendAppServicePlanSkus = "[]"
     $ENV:sharedStorageAccountContainerArray = "['blob-container-name']"
     $ENV:keyVaultAllowedIpAddressesList = "['111.1.1.1/32']"
     $ENV:keyVaultAllowedSubnetsList = "[]"
@@ -54,6 +55,7 @@ function Clear-MockEnvironment {
         "ENV:backendSubnetCount",
         "ENV:sharedWorkerSubnetCount",
         "ENV:sqlAdminPasswordSeed",
+        "ENV:backendAppServicePlanSkus",
         "ENV:sharedStorageAccountContainerArray",
         "ENV:keyVaultAllowedIpAddressesList",
         "ENV:keyVaultAllowedSubnetsList",


### PR DESCRIPTION
As part of the work to improve the reliability, flexibility and scalability of the platform we will add additional ASP’s so that the applications on the existing overloaded ASP’s can be distributed across them. This brings the application distribution across the new ASP’s inline with the Microsoft recommended application density.
The agreed approach to adding additional backend ASP’s is linked on the Confluence page:

https://skillsfundingagency.atlassian.net/wiki/spaces/NDL/pages/4456546308/Shared+Backend+ASP+Distribution

**_Steps done:_**

- Added new copy resource to the template to deploy n number of ASP’s depending on the number of configurations passed in to the backendAppServicePlanSkus parameter

- Added backEndAppServicePlanNamePrefix variable to ensure the backend ASP name is das-{ENV}-sharedbe-asp-0 where 0 will be 0, 1, 2, 3, 4 depending on the number of configurations passed in to the backendAppServicePlanSkus parameter

- Ensure that the backendSubnetCount parameter in the network.template.json aligns with the number of ASP configurations in the backendAppServicePlanSkus parameter. The backendSubnetCount parameter will be set to 2 as of this change