### PR TITLE
Added frontend app service plan deployment with copy loop for multiple ASP creation in the future

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -207,6 +207,13 @@
         "description": "Takes an array of objects: '[{\"identifier\": 0,\"tier\": \"Basic\",\"size\": \"1\",\"instances\": 1}]. Removing the backslash. The identifier helps map the values to the deployed ASP."
       }
     },
+    "frontendAppServicePlanSkus": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Takes an array of objects: '[{\"identifier\": 0,\"tier\": \"Basic\",\"size\": \"1\",\"instances\": 1}]. Removing the backslash. The identifier helps map the values to the deployed ASP."
+      }
+    },
     "sharedWorkerAppServicePlanSku": {
       "type": "object",
       "defaultValue": {
@@ -287,6 +294,7 @@
     "sharedFrontEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'fe-asp')]",
     "sharedBackEndAppServicePlanName": "[concat(variables('resourceNamePrefix'),'be-asp')]",
     "backEndAppServicePlanNamePrefix": "[concat(variables('resourceNamePrefix'), 'be-asp-')]",
+    "frontEndAppServicePlanNamePrefix": "[concat(variables('resourceNamePrefix'), 'fe-asp-')]",
     "sharedWorkerAppServicePlanName": "[concat(variables('resourceNamePrefix'),'wkr-asp')]",
     "firewallsResourceGroup": "[toLower(concat('das-', variables('environmentName'),'-firewall-rg'))]",
     "serviceBusNamespaceName": "[concat(variables('resourceNamePrefix'),'-ns')]",
@@ -655,6 +663,37 @@
           },
           "nonASETier": {
             "value": "[parameters('frontEndAppServicePlanSku').tier]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[concat('front-end-app-service-plan-', copyIndex(), '-', parameters('utcValue'))]",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "copy": {
+        "name": "frontendAppServicePlanLoop",
+        "count": "[length(parameters('frontendAppServicePlanSkus'))]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[uri(variables('deploymentUrlBase'),'app-service-plan.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "appServicePlanName": {
+            "value": "[concat(variables('frontEndAppServicePlanNamePrefix'), copyIndex())]"
+          },
+          "aspSize": {
+            "value": "[parameters('frontendAppServicePlanSkus')[copyIndex()].size]"
+          },
+          "aspInstances": {
+            "value": "[parameters('frontendAppServicePlanSkus')[copyIndex()].instances]"
+          },
+          "nonASETier": {
+            "value": "[parameters('frontendAppServicePlanSkus')[copyIndex()].tier]"
           }
         }
       }

--- a/templates/subscription.template.json
+++ b/templates/subscription.template.json
@@ -199,6 +199,14 @@
         "environmentVariable": "frontEndAppServicePlanSku"
       }
     },
+    "frontendAppServicePlanSkus": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "Takes an array of objects: '[{\"identifier\": 0,\"tier\": \"Basic\", \"size\": \"1\",\"instances\": 1}]. Removing the backslash. The identifier helps map the values to the deployed ASP.",
+        "environmentVariable": "frontendAppServicePlanSkus"
+      }
+    },
     "backEndAppServicePlanSku": {
       "type": "object",
       "defaultValue": {
@@ -715,6 +723,9 @@
           },
           "backendAppServicePlanSkus": {
             "value": "[parameters('backendAppServicePlanSkus')]"
+          },
+          "frontendAppServicePlanSkus": {
+            "value": "[parameters('frontendAppServicePlanSkus')]"
           },
           "sharedWorkerAppServicePlanSku": {
             "value": "[parameters('sharedWorkerAppServicePlanSku')[toUpper(parameters('environments')[copyIndex()])]]"

--- a/tests/modules/UnitTest.Helpers.psm1
+++ b/tests/modules/UnitTest.Helpers.psm1
@@ -20,6 +20,7 @@ function Set-MockEnvironment {
     $ENV:sqlAdminPasswordSeed = "test seed"
     $ENV:DatabaseConfiguration = "{}"
     $ENV:backendAppServicePlanSkus = "[]"
+    $ENV:frontendAppServicePlanSkus = "[]"
     $ENV:sharedStorageAccountContainerArray = "['blob-container-name']"
     $ENV:keyVaultAllowedIpAddressesList = "['111.1.1.1/32']"
     $ENV:keyVaultAllowedSubnetsList = "[]"
@@ -56,6 +57,7 @@ function Clear-MockEnvironment {
         "ENV:sharedWorkerSubnetCount",
         "ENV:sqlAdminPasswordSeed",
         "ENV:backendAppServicePlanSkus",
+        "ENV:frontendAppServicePlanSkus",
         "ENV:sharedStorageAccountContainerArray",
         "ENV:keyVaultAllowedIpAddressesList",
         "ENV:keyVaultAllowedSubnetsList",


### PR DESCRIPTION
As part of the work to improve the reliability, flexibility and scalability of the platform we will add additional ASP’s so that the applications on the existing overloaded ASP’s can be distributed across them. This brings the application distribution across the new ASP’s inline with the Microsoft recommended application density.
The agreed approach to adding additional frontend ASP’s is linked on the Confluence page:

https://skillsfundingagency.atlassian.net/wiki/spaces/NDL/pages/4433346593/Shared+Frontend+ASP+Distribution

**Steps done:**

- Added new copy resource to the template to deploy n number of ASP’s depending on the number of configurations passed in to the frontendAppServicePlanSkus parameter

- Added frontEndAppServicePlanNamePrefix variable to ensure the frontend ASP name is das-{ENV}-sharedfe-asp-0 where 0 will be 0, 1, 2, 3, 4 depending on the number of configurations passed in to the frontendAppServicePlanSkus parameter

- Ensure that the frontendSubnetCount parameter in the network.template.json aligns with the number of ASP configurations in the frontendAppServicePlanSkus parameter. The frontendSubnetCount parameter will be set to 2 as of this change