### PR TITLE
parameterised missing configuration

### DIFF
--- a/templates/environment.template.json
+++ b/templates/environment.template.json
@@ -1065,13 +1065,13 @@
             "value": "[variables('sharedRedisCacheName')]"
           },
           "redisCacheSKU": {
-            "value": "Standard"
+            "value": "[parameters('sharedRedisCacheSKU')]"
           },
           "redisCacheFamily": {
-            "value": "C"
+            "value": "[parameters('sharedRedisCacheFamily')]"
           },
           "redisCacheCapacity": {
-            "value": 1
+            "value": "[parameters('sharedRedisCacheCapacity')]"
           },
           "enableNonSslPort": {
             "value": false


### PR DESCRIPTION
Work was done here to parameterise the sku of redis cache: https://github.com/SkillsFundingAgency/das-shared-infrastructure/pull/103

However it wasn't realise that there is another arm template to do something in redis which has the redis SKU still hardcoded. This has caused production to scale from C2 to C1. Adding this code, ensures that the same SKU is used in both deployments.